### PR TITLE
Add implicit Aspects options onlyPublic, bypassParent, bypassTraits

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ class DiscountAspect
         // You can also use Wildcards (see Okapi/Wildcards package)
         class: Product::class . '|' . Order::class,
         method: 'get(Price|Total)',
+        // When using an eager wildcard you can need some of those combinable options:
+        // bool onlyPublic: will weave only public methods
+        // bool bypassParent: will weave only the matching Class and ignore parent classes hierarchy.
+        // bool bypassTrait: will weave only methods defining in Class, ignore those defined in Trait.
     )]
     public function applyDiscount(AfterMethodInvocation $invocation): void
     {

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ class DiscountAspect
         // When using an eager wildcard you can need some of those combinable options:
         // bool onlyPublic: will weave only public methods
         // bool bypassParent: will weave only the matching Class and ignore parent classes hierarchy.
-        // bool bypassTrait: will weave only methods defining in Class, ignore those defined in Trait.
+        // bool bypassTraits: will weave only methods defining in Class, ignore those defined in Trait.
     )]
     public function applyDiscount(AfterMethodInvocation $invocation): void
     {

--- a/src/Core/Attributes/AdviceType/MethodAdvice.php
+++ b/src/Core/Attributes/AdviceType/MethodAdvice.php
@@ -21,6 +21,7 @@ use Okapi\Wildcards\Regex;
 abstract class MethodAdvice extends BaseAdvice
 {
     public ?Regex $method;
+    public bool $onlyPublic;
 
     /**
      * MethodAdvice constructor.
@@ -32,8 +33,12 @@ abstract class MethodAdvice extends BaseAdvice
         ?string $class = null,
         ?string $method = null,
         int     $order = 0,
+        bool $bypassParent = false,
+        bool $bypassTraits = false,
+        bool $onlyPublic = false,
     ) {
-        parent::__construct($class, $order);
+        parent::__construct(class: $class, order: $order, bypassParent: $bypassParent, bypassTraits: $bypassTraits );
         $this->method = $method ? Regex::fromWildcard($method) : null;
+        $this->onlyPublic = $onlyPublic ;
     }
 }

--- a/src/Core/Attributes/Base/BaseAdvice.php
+++ b/src/Core/Attributes/Base/BaseAdvice.php
@@ -17,6 +17,14 @@ use Okapi\Wildcards\Regex;
 abstract class BaseAdvice extends BaseAttribute
 {
     public ?Regex $class;
+    /**
+     * Do not process methods defined in parent class.
+     */
+    public bool $bypassParent ;
+    /**
+     * Do not process methods defined in trait.
+     */
+    public bool $bypassTraits ;
 
     /**
      * Base advice constructor.
@@ -27,7 +35,11 @@ abstract class BaseAdvice extends BaseAttribute
     public function __construct(
         ?string    $class = null,
         public int $order = 0,
+        bool $bypassParent = false,
+        bool $bypassTraits = false,
     ) {
         $this->class = $class ? Regex::fromWildcard($class) : null;
+        $this->bypassParent = $bypassParent ;
+        $this->bypassTraits = $bypassTraits ;
     }
 }

--- a/src/Core/Matcher/AdviceMatcher/MethodMatcher.php
+++ b/src/Core/Matcher/AdviceMatcher/MethodMatcher.php
@@ -5,6 +5,7 @@ namespace Okapi\Aop\Core\Matcher\AdviceMatcher;
 use Okapi\Aop\Core\Container\AdviceType\MethodAdviceContainer;
 use Roave\BetterReflection\Reflection\ReflectionClass as BetterReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
+use ReflectionMethod as CoreReflectionMethod;
 
 /**
  * # Method Matcher
@@ -38,11 +39,33 @@ class MethodMatcher
                 );
             } else {
                 // Match implicit aspects
-                $newMethodAdviceContainer = $this->matchImplicit(
-                    $methodAdviceContainer,
-                    $refMethodToMatch,
-                    $newMethodAdviceContainer,
-                );
+
+                if( $methodAdviceContainer->adviceAttributeInstance->bypassParent 
+                    &&  in_array(
+                        $refMethodToMatch->getImplementingClass()->getName(),
+                        $refMethodToMatch->getCurrentClass()->getParentClassNames() )
+                ){
+                    // bypass parent classes
+                }
+                else if( $methodAdviceContainer->adviceAttributeInstance->bypassTraits
+                    && $refMethodToMatch->getDeclaringClass()->isTrait()
+                ){
+                    // bypass used traits
+                }
+                else if( 
+                    $methodAdviceContainer->adviceAttributeInstance->onlyPublic
+                    && ! ($refMethodToMatch->getModifiers() & CoreReflectionMethod::IS_PUBLIC)
+                ){
+                    // bypass no public methods
+                }
+                else
+                {
+                    $newMethodAdviceContainer = $this->matchImplicit(
+                        $methodAdviceContainer,
+                        $refMethodToMatch,
+                        $newMethodAdviceContainer,
+                    );
+                }
             }
         }
 

--- a/src/Core/Matcher/ClassMatcher.php
+++ b/src/Core/Matcher/ClassMatcher.php
@@ -52,15 +52,23 @@ class ClassMatcher
             $refClass,
         );
 
-        $parentClassesMatches = $this->matchParentClasses(
-            $classRegex,
-            $refClass,
-        );
+        $parentClassesMatches = false ;
+        if( ! $adviceAttributeInstance->bypassParent )
+        {
+            $parentClassesMatches = $this->matchParentClasses(
+                $classRegex,
+                $refClass,
+            );
+        }
 
-        $traitsMatches = $this->matchTraits(
-            $classRegex,
-            $refClass,
-        );
+        $traitsMatches = false ;
+        if( ! $adviceAttributeInstance->bypassTraits )
+        {
+            $traitsMatches = $this->matchTraits(
+                $classRegex,
+                $refClass,
+            );
+        }
 
         return $classMatches
             || $interfacesMatches

--- a/tests/Functional/Advice/AdviceBypassParents/AdviceBypassParentsTest.php
+++ b/tests/Functional/Advice/AdviceBypassParents/AdviceBypassParentsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+use Okapi\Aop\Tests\Stubs\Kernel\ApplicationKernel;
+use Okapi\Aop\Tests\Util;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+class AdviceBypassParentsTest extends TestCase
+{
+    /**
+     * @see ArticleModerationAspect::validateContent()
+     * @see ArticleModerationAspect::checkForSpam()
+     * @see ArticleModerationAspect::ensureProperFormatting()
+     */
+    public function testAdviceBypassParents(): void
+    {
+        Util::clearCache();
+        TargetKernel::init();
+
+        $targetClass = new TargetClass();
+
+        $targetClass->helloWorld();
+        $targetClass->helloHere();
+
+        $stackTrace = StackTrace::getInstance();
+        $this->assertEquals(
+            [
+                'AspectDefault',
+                'AspectBypassParents',
+                'AspectDefault',
+            ],
+            $stackTrace->getStackTrace(),
+        );
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassParents/AspectBypassParents.php
+++ b/tests/Functional/Advice/AdviceBypassParents/AspectBypassParents.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectBypassParents
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+        bypassParent: true,
+    )]
+    public function aspectBypassParents_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectBypassParents');
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassParents/AspectDefault.php
+++ b/tests/Functional/Advice/AdviceBypassParents/AspectDefault.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectDefault
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+    )]
+    public function aspectDefault_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectDefault');
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassParents/TargetClass.php
+++ b/tests/Functional/Advice/AdviceBypassParents/TargetClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+class TargetClass extends TargetParentClass {
+    public function helloWorld()
+    {
+    }
+}
+

--- a/tests/Functional/Advice/AdviceBypassParents/TargetKernel.php
+++ b/tests/Functional/Advice/AdviceBypassParents/TargetKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+use Okapi\Aop\AopKernel;
+use Okapi\Aop\Tests\Util;
+
+class TargetKernel extends AopKernel
+{
+    protected ?string $cacheDir = Util::CACHE_DIR;
+
+    protected array $aspects = [
+        AspectDefault::class,
+        AspectBypassParents::class,
+    ];
+}

--- a/tests/Functional/Advice/AdviceBypassParents/TargetParentClass.php
+++ b/tests/Functional/Advice/AdviceBypassParents/TargetParentClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassParents;
+
+class TargetParentClass {
+    public function helloHere()
+    {
+    }
+}
+

--- a/tests/Functional/Advice/AdviceBypassTraits/AdviceBypassTraitsTest.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/AdviceBypassTraitsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+use Okapi\Aop\Tests\Stubs\Kernel\ApplicationKernel;
+use Okapi\Aop\Tests\Util;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+class AdviceBypassTraitsTest extends TestCase
+{
+    /**
+     * @see ArticleModerationAspect::validateContent()
+     * @see ArticleModerationAspect::checkForSpam()
+     * @see ArticleModerationAspect::ensureProperFormatting()
+     */
+    public function testAdviceBypassTraits(): void
+    {
+        Util::clearCache();
+        TargetKernel::init();
+
+        $targetClass = new TargetClass();
+
+        $targetClass->helloWorld();
+        $targetClass->helloHere();
+
+        $stackTrace = StackTrace::getInstance();
+        $this->assertEquals(
+            [
+                'AspectDefault',
+                'AspectBypassTraits',
+                'AspectDefault',
+            ],
+            $stackTrace->getStackTrace(),
+        );
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassTraits/AspectBypassTraits.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/AspectBypassTraits.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectBypassTraits
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+        bypassTraits: true,
+    )]
+    public function aspectBypassTraits_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectBypassTraits');
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassTraits/AspectDefault.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/AspectDefault.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectDefault
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+    )]
+    public function aspectDefault_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectDefault');
+    }
+}

--- a/tests/Functional/Advice/AdviceBypassTraits/TargetClass.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/TargetClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+class TargetClass {
+    use TargetTrait ;
+    public function helloWorld()
+    {
+    }
+}
+

--- a/tests/Functional/Advice/AdviceBypassTraits/TargetKernel.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/TargetKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+use Okapi\Aop\AopKernel;
+use Okapi\Aop\Tests\Util;
+
+class TargetKernel extends AopKernel
+{
+    protected ?string $cacheDir = Util::CACHE_DIR;
+
+    protected array $aspects = [
+        AspectDefault::class,
+        AspectBypassTraits::class,
+    ];
+}

--- a/tests/Functional/Advice/AdviceBypassTraits/TargetTrait.php
+++ b/tests/Functional/Advice/AdviceBypassTraits/TargetTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceBypassTraits;
+
+trait TargetTrait {
+    public function helloHere()
+    {
+    }
+}
+

--- a/tests/Functional/Advice/AdviceOnlyPublic/AdviceOnlyPublicTest.php
+++ b/tests/Functional/Advice/AdviceOnlyPublic/AdviceOnlyPublicTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic;
+
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+use Okapi\Aop\Tests\Stubs\Kernel\ApplicationKernel;
+use Okapi\Aop\Tests\Util;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+class AdviceOnlyPublicTest extends TestCase
+{
+    /**
+     * @see ArticleModerationAspect::validateContent()
+     * @see ArticleModerationAspect::checkForSpam()
+     * @see ArticleModerationAspect::ensureProperFormatting()
+     */
+    public function testAdviceOnlyPublic(): void
+    {
+        Util::clearCache();
+        TargetKernel::init();
+
+        $targetClass = new TargetClass();
+
+        $targetClass->helloWorld();
+        $targetClass->helloHere();
+
+        $stackTrace = StackTrace::getInstance();
+        $this->assertEquals(
+            [
+                'AspectDefault',
+                'AspectOnlyPublic',
+                'AspectDefault',
+            ],
+            $stackTrace->getStackTrace(),
+        );
+    }
+}

--- a/tests/Functional/Advice/AdviceOnlyPublic/AspectDefault.php
+++ b/tests/Functional/Advice/AdviceOnlyPublic/AspectDefault.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Functional\Advice\AdviceOrder\ClassesToIntercept\ArticleManager;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectDefault
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+    )]
+    public function aspectDefault_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectDefault');
+    }
+}

--- a/tests/Functional/Advice/AdviceOnlyPublic/AspectOnlyPublic.php
+++ b/tests/Functional/Advice/AdviceOnlyPublic/AspectOnlyPublic.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic;
+
+use Okapi\Aop\Attributes\After;
+use Okapi\Aop\Attributes\Aspect;
+use Okapi\Aop\Tests\Functional\Advice\AdviceOrder\ClassesToIntercept\ArticleManager;
+use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
+
+#[Aspect]
+class AspectOnlyPublic
+{
+    #[After(
+        class: TargetClass::class,
+        method: '*',
+        onlyPublic: true,
+    )]
+    public function aspectOnlyPublic_validateContent()
+    {
+        $stackTrace = StackTrace::getInstance();
+        $stackTrace->addTrace('AspectOnlyPublic');
+    }
+}

--- a/tests/Functional/Advice/AdviceOnlyPublic/TargetClass.php
+++ b/tests/Functional/Advice/AdviceOnlyPublic/TargetClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic;
+
+class TargetClass {
+    public function helloWorld()
+    {
+    }
+    protected function helloHere()
+    {
+    }
+}
+

--- a/tests/Functional/Advice/AdviceOnlyPublic/TargetKernel.php
+++ b/tests/Functional/Advice/AdviceOnlyPublic/TargetKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic;
+
+use Okapi\Aop\AopKernel;
+use Okapi\Aop\Tests\Util;
+
+class TargetKernel extends AopKernel
+{
+    protected ?string $cacheDir = Util::CACHE_DIR;
+
+    protected array $aspects = [
+        AspectDefault::class,
+        AspectOnlyPublic::class,
+    ];
+}

--- a/tests/Functional/Advice/AdviceOrder/AdviceOrderTest.php
+++ b/tests/Functional/Advice/AdviceOrder/AdviceOrderTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Okapi\Aop\Tests\Functional\AdviceOrder;
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOrder;
 
-use Okapi\Aop\Tests\Functional\AdviceOrder\Aspect\ArticleModerationAspect;
+use Okapi\Aop\Tests\Functional\Advice\AdviceOrder\Aspect\ArticleModerationAspect;
 use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
 use Okapi\Aop\Tests\Stubs\Kernel\ApplicationKernel;
 use Okapi\Aop\Tests\Util;

--- a/tests/Functional/Advice/AdviceOrder/Aspect/ArticleModerationAspect.php
+++ b/tests/Functional/Advice/AdviceOrder/Aspect/ArticleModerationAspect.php
@@ -1,11 +1,11 @@
 <?php
 /** @noinspection PhpUnused */
 /** @noinspection PhpMissingReturnTypeInspection */
-namespace Okapi\Aop\Tests\Functional\AdviceOrder\Aspect;
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOrder\Aspect;
 
 use Okapi\Aop\Attributes\After;
 use Okapi\Aop\Attributes\Aspect;
-use Okapi\Aop\Tests\Functional\AdviceOrder\ClassesToIntercept\ArticleManager;
+use Okapi\Aop\Tests\Functional\Advice\AdviceOrder\ClassesToIntercept\ArticleManager;
 use Okapi\Aop\Tests\Stubs\Etc\StackTrace;
 
 #[Aspect]

--- a/tests/Functional/Advice/AdviceOrder/ClassesToIntercept/ArticleManager.php
+++ b/tests/Functional/Advice/AdviceOrder/ClassesToIntercept/ArticleManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Okapi\Aop\Tests\Functional\AdviceOrder\ClassesToIntercept;
+namespace Okapi\Aop\Tests\Functional\Advice\AdviceOrder\ClassesToIntercept;
 
 class ArticleManager
 {

--- a/tests/Stubs/Kernel/ApplicationKernel.php
+++ b/tests/Stubs/Kernel/ApplicationKernel.php
@@ -5,7 +5,7 @@ namespace Okapi\Aop\Tests\Stubs\Kernel;
 use Okapi\Aop\AopKernel;
 use Okapi\Aop\Tests\Functional\AbstractMethod\Aspect\FileUploaderAspect;
 use Okapi\Aop\Tests\Functional\AdviceMatchingMultipleClassesAndMethods\Aspect\DiscountAspect;
-use Okapi\Aop\Tests\Functional\AdviceOrder\Aspect\ArticleModerationAspect;
+use Okapi\Aop\Tests\Functional\Advice\AdviceOrder\Aspect\ArticleModerationAspect;
 use Okapi\Aop\Tests\Functional\BeforeAroundAfterAdviceOnSameAdviceMethod\Aspect\CalculatorLoggerAspect;
 use Okapi\Aop\Tests\Functional\BeforeAroundAfterAdviceOnSameTargetMethod\Aspect\PaymentProcessorAspect;
 use Okapi\Aop\Tests\Functional\ClassHierarchyAspect\Aspect\NotificationAspect;
@@ -36,5 +36,7 @@ class ApplicationKernel extends AopKernel
         RouteCachingAspect::class,
         SalaryIncreaserAspect::class,
         UserInterfaceAspect::class,
+        \Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic\AspectDefault::class,
+        \Okapi\Aop\Tests\Functional\Advice\AdviceOnlyPublic\AspectOnlyPublic::class,
     ];
 }


### PR DESCRIPTION
Hi here :-)

To follow issues #29 and #30 I propose some options in this pull request, which are useful when using an eager wildcard with implicit Aspect:

- bool **onlyPublic**: will weave only public methods
- bool **bypassParent**: will weave only the matching Class and ignore parent classes hierarchy.
- bool **bypassTraits**: will weave only methods defining in Class, ignore those defined in Trait.

They are UnitTests in `tests/Functional/Advice` and the `README.md` is updated too.
